### PR TITLE
Clarify ActiveStorage::Attached::Model docs [ci skip]

### DIFF
--- a/activestorage/lib/active_storage/attached/model.rb
+++ b/activestorage/lib/active_storage/attached/model.rb
@@ -71,8 +71,10 @@ module ActiveStorage
       # and +avatar_blob+. But you shouldn't need to work with these associations directly in
       # most circumstances.
       #
-      # The system has been designed to having you go through the ActiveStorage::Attached::One
-      # proxy that provides the dynamic proxy to the associations and factory methods, like +attach+.
+      # Instead, +has_one_attached+ generates an ActiveStorage::Attached::One proxy to
+      # provide access to the associations and factory methods, like +attach+:
+      #
+      #   user.avatar.attach(uploaded_file)
       #
       # The +:dependent+ option defaults to +:purge_later+. This means the attachment will be
       # purged (i.e. destroyed) in the background whenever the record is destroyed.
@@ -171,8 +173,10 @@ module ActiveStorage
       # and +photos_blobs+. But you shouldn't need to work with these associations directly in
       # most circumstances.
       #
-      # The system has been designed to having you go through the ActiveStorage::Attached::Many
-      # proxy that provides the dynamic proxy to the associations and factory methods, like +#attach+.
+      # Instead, +has_one_attached+ generates an ActiveStorage::Attached::Many proxy to
+      # provide access to the associations and factory methods, like +attach+:
+      #
+      #   user.photos.attach(uploaded_file)
       #
       # The +:dependent+ option defaults to +:purge_later+. This means the attachments will be
       # purged (i.e. destroyed) in the background whenever the record is destroyed.


### PR DESCRIPTION
### Motivation / Background

The docs on has_one_attached / has_many_attached include this confusing sentence:

```
The system has been designed to having you go through the ActiveStorage::Attached::One
proxy that provides the dynamic proxy to the associations and factory methods, like +attach+.
```

### Detail

This Pull Request tries to improve grammar & clarity.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Unrelated changes should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature. Minor bug fixes and documentation changes should not be included.
